### PR TITLE
refactor: flatten control flow using when-let*/if-let*

### DIFF
--- a/blame-reveal.el
+++ b/blame-reveal.el
@@ -822,7 +822,7 @@ Uses magit if `blame-reveal-use-magit' is configured to do so."
   "Show the git log history of current file.
 Uses magit if `blame-reveal-use-magit' is configured to do so."
   (interactive)
-  (if-let ((file (buffer-file-name)))
+  (if-let* ((file (buffer-file-name)))
       (if (vc-git-registered file)
           (if (blame-reveal--should-use-magit-p)
               (magit-log-buffer-file)
@@ -851,7 +851,7 @@ Uses magit if `blame-reveal-use-magit' is configured to do so."
   "Show the git log history of current line.
 This function always uses built-in git."
   (interactive)
-  (if-let ((file (buffer-file-name)))
+  (if-let* ((file (buffer-file-name)))
       (if (vc-git-registered file)
           (let* ((line-num (line-number-at-pos))
                  (buffer-name (format "*Git Log: %s:%d*"


### PR DESCRIPTION
Replace deep let → if → let chains with flat, linear control flow:
- Use when/when-let* to wrap code blocks instead of cl-return-from
- Extract helper functions to reduce nesting depth
- Replace if-let with if-let* (Emacs 31.1 deprecation)

Files modified:
- blame-reveal-git.el: Refactor sync/async loading and commit info
- blame-reveal-ui.el: Flatten rendering and header update logic
- blame-reveal-header.el: Simplify sticky header updates
- blame-reveal-focus.el: Flatten focus mode rendering
- blame-reveal-recursive.el: Simplify error handling
- blame-reveal.el: if-let -> if-let*